### PR TITLE
Update .gitignore to get rid of core build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 *.o 
 *.so 
+*.la
+*.lo
 sample
+Makefile
+.deps/
+.libs/
+/autom4te.cache
+/config.*
+/libtool
+/stamp-h1


### PR DESCRIPTION
This fixes the Core build issue of https://github.com/smartdevicelink/sdl_core/issues/1717.