### PR TITLE
Add a cocoapod podspec

### DIFF
--- a/BiSON.podspec
+++ b/BiSON.podspec
@@ -71,6 +71,6 @@ Pod::Spec.new do |s|
   #
 
   s.source_files  = "src/*.{h,c}", "src/emhashmap/*.{h,c}"
-  s.header_mappings_dir = 'src/emhashmap'
+  s.header_mappings_dir = 'src'
 
 end

--- a/BiSON.podspec
+++ b/BiSON.podspec
@@ -70,6 +70,7 @@ Pod::Spec.new do |s|
   #  Not including the public_header_files will make all headers public.
   #
 
-  s.source_files  = "src/**/*.{h,c}"
+  s.source_files  = "src/*.{h,c}", "src/emhashmap/*.{h,c}"
+  s.header_mappings_dir = 'src/emhashmap'
 
 end

--- a/BiSON.podspec
+++ b/BiSON.podspec
@@ -1,0 +1,75 @@
+#
+#  Be sure to run `pod spec lint BiSON.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  s.name         = "BiSON"
+  s.version      = "1.0.0"
+  s.summary      = "A portable BSON C library"
+
+
+  s.homepage     = "https://github.com/smartdevicelink/bson_c_lib"
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See http://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  s.license      = { :type => "New BSD", :file => "LICENSE" }
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+  s.author            = { "SmartDeviceLink Team" => "developer@smartdevicelink.com" }
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  #  When using multiple platforms
+  s.ios.deployment_target = "6.0"
+  s.osx.deployment_target = "10.7"
+  s.watchos.deployment_target = "2.0"
+  s.tvos.deployment_target = "9.0"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  s.source       = { :git => "https://github.com/smartdevicelink/bson_c_lib.git", :tag => s.version.to_s }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any swift, h, m, mm, c & cpp files.
+  #  For header files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  s.source_files  = "src/**/*.{h,c}"
+
+end

--- a/BiSON.podspec
+++ b/BiSON.podspec
@@ -26,6 +26,7 @@ Pod::Spec.new do |s|
   #
 
   s.license      = { :type => "New BSD", :file => "LICENSE" }
+  s.preserve_path = 'src/emhashmap/LICENSE' 
 
 
   # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ make
 sudo make install
 ```
 
+### Apple Platforms ###
+There is a CocoaPod for iOS, MacOS, tvOS, and watchOS. Add to your podfile:
+
+```ruby
+pod 'BiSON'
+```
+
 ## Build and run sample program ##
 ```bash
 cd examples


### PR DESCRIPTION
We need this to work as a dependency on SmartDeviceLink-iOS, and so it needs a podspec. It may also be useful to other developers. This will need to be updated in the future if more releases are created.