### PR TITLE
Update .gitignore again to get rid of core build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-*.o 
-*.so 
+*.o
+*.so
 *.la
 *.lo
 sample


### PR DESCRIPTION
I noticed I still see a build error of SDL Core if the system has old version of git (for example, version 1.9.1).
Fixing .gitignore once again to properly ignore object files.