### PR TITLE
Fix implicit casts

### DIFF
--- a/src/bson_array.c
+++ b/src/bson_array.c
@@ -176,7 +176,7 @@ BsonArray bson_array_from_bytes(uint8_t *data) {
         //String length is read first
         int32_t stringLength = read_int32_le(&current) - 1;
 
-        char *stringVal = byte_array_to_bson_string(current, stringLength);
+        char *stringVal = byte_array_to_bson_string(current, (size_t)stringLength);
         bson_array_add_string(&array, stringVal);
         free(stringVal);
         current += stringLength + 1;

--- a/src/bson_object.c
+++ b/src/bson_object.c
@@ -6,7 +6,7 @@ size_t hash_function(const char* key, size_t maxValue) {
   size_t hash = 0;
   int i;
   for (i = 0; i < keyLength; i++) {
-    hash += key[i];
+    hash += (uint32_t)key[i];
     hash %= maxValue;
   }
   return hash;
@@ -197,7 +197,7 @@ BsonObject bson_object_from_bytes(uint8_t *data) {
         //String length is read first
         int32_t stringLength = read_int32_le(&current) - 1;
 
-        char *stringVal = byte_array_to_bson_string(current, stringLength);
+        char *stringVal = byte_array_to_bson_string(current, (size_t)stringLength);
         bson_object_put_string(&obj, key, stringVal);
         free(stringVal);
         current += stringLength + 1;

--- a/src/bson_object.c
+++ b/src/bson_object.c
@@ -6,7 +6,7 @@ size_t hash_function(const char* key, size_t maxValue) {
   size_t hash = 0;
   int i;
   for (i = 0; i < keyLength; i++) {
-    hash += (uint32_t)key[i];
+    hash += (size_t)key[i];
     hash %= maxValue;
   }
   return hash;

--- a/src/bson_util.c
+++ b/src/bson_util.c
@@ -73,7 +73,7 @@ uint8_t *string_to_byte_array(char *stringVal) {
   uint8_t *bytes = malloc(length + 1);
   int i = 0;
   for (i = 0; i < length; i++) {
-    bytes[i] = stringVal[i];
+    bytes[i] = (uint8_t)stringVal[i];
   }
   bytes[length] = 0x00;
   return bytes;
@@ -97,7 +97,7 @@ char *byte_array_to_bson_string(uint8_t *bytes, size_t length) {
   
   int i = 0;
   for (i = 0; i < length; i++) {
-    stringVal[i] = bytes[i] & 0xFF;
+    stringVal[i] = (char)(bytes[i] & 0xFF);
   }
   stringVal[length] = 0x00;
   return stringVal;

--- a/src/emhashmap/emhashmap.c
+++ b/src/emhashmap/emhashmap.c
@@ -10,7 +10,7 @@ static MapBucketList* find_bucket(HashMap* map, const char* key) {
     MapBucketList* bucket = NULL;
 
     if(map != NULL && map->buckets != NULL) {
-        bucket = &map->buckets[(*map->hash)(key, map->bucket_count)];
+        bucket = &map->buckets[(*map->hash)(key, (size_t)map->bucket_count)];
     }
     return bucket;
 }
@@ -30,11 +30,10 @@ void emhashmap_deinitialize(HashMap* map) {
 bool emhashmap_initialize(HashMap* map, int capacity, float load_factor, size_t (*hash_function)(const char*, size_t)) {
     map->bucket_count = ((int)(capacity / load_factor) + 1);
     map->capacity = capacity;
-    map->entries = (MapEntry*) malloc(sizeof(MapEntry) * map->capacity);
-    memset(map->entries, 0, sizeof(MapEntry) * map->capacity);
-    map->buckets = (MapBucketList*) malloc(sizeof(MapBucketList) *
-            map->bucket_count);
-    memset(map->buckets, 0, sizeof(MapBucketList) * map->bucket_count);
+    map->entries = (MapEntry*) malloc(sizeof(MapEntry) * (uint32_t)map->capacity);
+    memset(map->entries, 0, sizeof(MapEntry) * (uint32_t)map->capacity);
+    map->buckets = (MapBucketList*) malloc(sizeof(MapBucketList) * (uint32_t)map->bucket_count);
+    memset(map->buckets, 0, sizeof(MapBucketList) * (uint32_t)map->bucket_count);
     map->hash = hash_function;
     int i;
     for(i = 0; i < map->bucket_count; i++) {


### PR DESCRIPTION
Updates to the iOS project's warnings revealed several implicit casts within BiSON. These have been made explicit.

Note: This does change enhashmap as well