### PR TITLE
Move all struct and typedefs to separate header

### DIFF
--- a/src/bson_array.h
+++ b/src/bson_array.h
@@ -1,24 +1,8 @@
 #ifndef BSON_ARRAY_H
 #define BSON_ARRAY_H
 
+#include "bson_fwd.h"
 #include "bson_object.h"
-
-typedef struct BsonElement BsonElement;
-typedef struct BsonObject BsonObject;
-
-typedef enum bson_boolean bson_boolean;
-typedef enum element_type element_type;
-
-//Object representing a BSON array
-struct BsonArray {
-  //Array of BSON elements
-  BsonElement **elements;
-  //Number of elements currently in the array
-  size_t count;
-  //The current maximum number of elements in the array
-  size_t maxCount;
-};
-typedef struct BsonArray BsonArray;
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bson_fwd.h
+++ b/src/bson_fwd.h
@@ -1,0 +1,75 @@
+#ifndef BSON_FWD_H
+#define BSON_FWD_H
+
+#include "emhashmap/emhashmap.h"
+
+//Byte which defines the type of a value as defined in the BSON spec
+enum element_type {
+  TYPE_DOUBLE = 0x01,
+  TYPE_STRING = 0x02,
+  TYPE_DOCUMENT = 0x03,
+  TYPE_ARRAY = 0x04,
+  TYPE_BINARY = 0x05, //unused
+  TYPE_UNDEFINED = 0x06, //deprecated
+  TYPE_OBJECT_ID = 0x07, //unused
+  TYPE_BOOLEAN = 0x08,
+  TYPE_DATE_TIME = 0x09, //unused
+  TYPE_NULL = 0x0A, //unused
+  TYPE_REGEX = 0x0B, //unused
+  TYPE_DB_POINTER = 0x0C, //deprecated
+  TYPE_JS_CODE = 0x0D, //unused
+  TYPE_SYMBOL = 0x0E, //deprecated
+  TYPE_JS_CODE_WITH_SCOPE = 0x0F, //unused
+  TYPE_INT32 = 0x10,
+  TYPE_TIMESTAMP = 0x11, //unused
+  TYPE_INT64 = 0x12,
+  TYPE_DEC128 = 0x13, //unused
+  TYPE_MIN_KEY = 0xFF, //unused
+  TYPE_MAX_KEY = 0x7F //unused
+};
+typedef enum element_type element_type;
+
+//Definition of each boolean value according to the BSON spec
+enum bson_boolean {
+  BOOLEAN_INVALID = -1,
+  BOOLEAN_FALSE = 0x00,
+  BOOLEAN_TRUE = 0x01
+};
+typedef enum bson_boolean bson_boolean;
+
+
+struct BsonObject {
+  //Internal map implementation
+  HashMap data;
+};
+typedef struct BsonObject BsonObject;
+
+struct BsonElement {
+  //The value of this element
+  void *value;
+  //The data type of this element
+  element_type type;
+  //Size of the element in bytes when converted to BSON 
+  //Unused for TYPE_DOCUMENT and TYPE_ARRAY
+  size_t size;
+};
+typedef struct BsonElement BsonElement;
+
+struct BsonObjectEntry {
+  char key[255];
+  BsonElement *element;
+};
+typedef struct BsonObjectEntry BsonObjectEntry;
+
+//Object representing a BSON array
+struct BsonArray {
+  //Array of BSON elements
+  BsonElement **elements;
+  //Number of elements currently in the array
+  size_t count;
+  //The current maximum number of elements in the array
+  size_t maxCount;
+};
+typedef struct BsonArray BsonArray;
+
+#endif  // BSON_FWD_H

--- a/src/bson_object.h
+++ b/src/bson_object.h
@@ -4,37 +4,10 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#include "bson_fwd.h"
 #include "bson_util.h"
 #include "bson_array.h"
 #include "emhashmap/emhashmap.h"
-
-typedef struct BsonArray BsonArray;
-
-typedef enum element_type element_type;
-typedef enum bson_boolean bson_boolean;
-
-struct BsonObject {
-  //Internal map implementation
-  HashMap data;
-};
-typedef struct BsonObject BsonObject;
-
-struct BsonElement {
-  //The value of this element
-  void *value;
-  //The data type of this element
-  element_type type;
-  //Size of the element in bytes when converted to BSON 
-  //Unused for TYPE_DOCUMENT and TYPE_ARRAY
-  size_t size;
-};
-typedef struct BsonElement BsonElement;
-
-struct BsonObjectEntry {
-  char key[255];
-  BsonElement *element;
-};
-typedef struct BsonObjectEntry BsonObjectEntry;
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bson_util.h
+++ b/src/bson_util.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
+#include "bson_fwd.h"
 
 //4 bytes for length, one for ending null character
 #define OBJECT_OVERHEAD_BYTES 5
@@ -24,39 +25,6 @@
 //Last byte in a BSON document
 #define DOCUMENT_END 0x00
 
-//Byte which defines the type of a value as defined in the BSON spec
-enum element_type {
-  TYPE_DOUBLE = 0x01,
-  TYPE_STRING = 0x02,
-  TYPE_DOCUMENT = 0x03,
-  TYPE_ARRAY = 0x04,
-  TYPE_BINARY = 0x05, //unused
-  TYPE_UNDEFINED = 0x06, //deprecated
-  TYPE_OBJECT_ID = 0x07, //unused
-  TYPE_BOOLEAN = 0x08,
-  TYPE_DATE_TIME = 0x09, //unused
-  TYPE_NULL = 0x0A, //unused
-  TYPE_REGEX = 0x0B, //unused
-  TYPE_DB_POINTER = 0x0C, //deprecated
-  TYPE_JS_CODE = 0x0D, //unused
-  TYPE_SYMBOL = 0x0E, //deprecated
-  TYPE_JS_CODE_WITH_SCOPE = 0x0F, //unused
-  TYPE_INT32 = 0x10,
-  TYPE_TIMESTAMP = 0x11, //unused
-  TYPE_INT64 = 0x12,
-  TYPE_DEC128 = 0x13, //unused
-  TYPE_MIN_KEY = 0xFF, //unused
-  TYPE_MAX_KEY = 0x7F //unused
-};
-typedef enum element_type element_type;
-
-//Definition of each boolean value according to the BSON spec
-enum bson_boolean {
-  BOOLEAN_INVALID = -1,
-  BOOLEAN_FALSE = 0x00,
-  BOOLEAN_TRUE = 0x01
-};
-typedef enum bson_boolean bson_boolean;
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
According to C standard :
ISO/IEC 9899:1999 + TC3 6.2.6/6:
```
The following identifiers have no linkage: an identifier declared to be anything other than an object or a function [...]
```
ISO/IEC 9899:1999 + TC3 6.2.6/6:
```
If an identifier has no linkage, there shall be no more than one declaration of the identifier (in a declarator or type specifier) with the same scope and in the same name space, except for tags as specified in 6.7.2.3.
```

Typedefs cannot be defined multiple times.
Because of that bson_c_lib failes to compile with gcc4.4.2