### PR TITLE
Update gradle file

### DIFF
--- a/BsonJavaPort/bson_java_port/build.gradle
+++ b/BsonJavaPort/bson_java_port/build.gradle
@@ -2,13 +2,12 @@ apply plugin: 'com.android.library'
 
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 19
-        versionCode 1
-        versionName "1.1.1"
+        targetSdkVersion 26
+        versionCode 2
+        versionName "1.1.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         ndk{
             abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
@@ -43,8 +42,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 

--- a/BsonJavaPort/bson_java_port/build.gradle
+++ b/BsonJavaPort/bson_java_port/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 8
         targetSdkVersion 26
         versionCode 2
-        versionName "1.1.2"
+        versionName "1.2.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         ndk{
             abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"

--- a/BsonJavaPort/bson_java_port/src/androidTest/java/com/livio/bsonjavaport/BsonEncoderTests.java
+++ b/BsonJavaPort/bson_java_port/src/androidTest/java/com/livio/bsonjavaport/BsonEncoderTests.java
@@ -1,8 +1,8 @@
 package com.livio.bsonjavaport;
 
-import android.test.AndroidTestCase;
-
 import com.livio.BSON.BsonEncoder;
+
+import junit.framework.TestCase;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -15,7 +15,7 @@ import java.util.Set;
  *
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
-public class BsonEncoderTests extends AndroidTestCase{
+public class BsonEncoderTests extends TestCase {
 
 	private HashMap<String, Object> testMapA;
 	private HashMap<String, Object> testMapB;

--- a/BsonJavaPort/build.gradle
+++ b/BsonJavaPort/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.4.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/BsonJavaPort/gradle/wrapper/gradle-wrapper.properties
+++ b/BsonJavaPort/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 22 14:21:10 EDT 2018
+#Wed May 01 11:39:48 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
This PR updates `build.gradle` file for `bson_java_port` module to:
- Use the newest dependencies 
- Remove `buildToolsVersion` since it no longer required (in fact gradle shows a warning when it is used)
- Update `compileSdkVersion`, `targetSdkVersion`, and `versionCode`