### PR TITLE
Use JUnit assertions in unit tests

### DIFF
--- a/BsonJavaPort/bson_java_port/src/androidTest/java/com/livio/bsonjavaport/BsonEncoderTests.java
+++ b/BsonJavaPort/bson_java_port/src/androidTest/java/com/livio/bsonjavaport/BsonEncoderTests.java
@@ -97,7 +97,7 @@ public class BsonEncoderTests extends TestCase {
 			try {
 				assertEquals(observedMapAbytes[i], testMapAbytes[i]);
 			}catch (Exception e){
-				assert(false);
+				fail();
 			}
 		}
 
@@ -106,7 +106,7 @@ public class BsonEncoderTests extends TestCase {
 			try {
 				assertEquals(observedMapBbytes[i], testMapBbytes[i]);
 			}catch (Exception e){
-				assert(false);
+				fail();
 			}
 		}
 	}
@@ -115,8 +115,8 @@ public class BsonEncoderTests extends TestCase {
 		HashMap<String, Object> decodedMapA = BsonEncoder.decodeFromBytes(testMapAbytes);
 		HashMap<String, Object> decodedMapB = BsonEncoder.decodeFromBytes(testMapBbytes);
 
-		assert(compareHashMaps(testMapA, decodedMapA));
-		assert(compareHashMaps(testMapB, decodedMapB));
+		assertTrue(compareHashMaps(testMapA, decodedMapA));
+		assertTrue(compareHashMaps(testMapB, decodedMapB));
 	}
 
 	public void testDecodingRandomData() {
@@ -130,7 +130,7 @@ public class BsonEncoderTests extends TestCase {
 		// Test nested objects and arrays
         byte[] bytes = BsonEncoder.encodeToBytes(testMapC);
         HashMap<String, Object> outMap = BsonEncoder.decodeFromBytes(bytes);
-        assert(testMapC.equals(outMap));
+		assertEquals(testMapC, outMap);
 	}
 
 	private boolean compareHashMaps(HashMap<String,Object> testMap, HashMap<String,Object> obsvMap){


### PR DESCRIPTION
Unit tests currently use the JVM's `assert()` instead of the JUnit's `assertTrue()` and `assertEquals()`... . However, the JVM's `assert()` is ignored unless we do some extra setup. So it is better to use JUnit's assertions in unit testing. 
