### PR TITLE
Fix error in deprecated `bson_object_from_bytes` method

### DIFF
--- a/src/bson_array.c
+++ b/src/bson_array.c
@@ -144,7 +144,10 @@ BsonArray bson_array_from_bytes(uint8_t *data) {
   int32_t size = read_int32_le(&p);
 
   BsonArray array;
-  bson_array_from_bytes_len(&array, data, size);
+  size_t bytes = bson_array_from_bytes_len(&array, data, size);
+  if (bytes <= 0) {
+    bson_array_initialize(&array, 10);
+  }
   return array;
 }
 

--- a/src/bson_object.c
+++ b/src/bson_object.c
@@ -165,7 +165,10 @@ BsonObject bson_object_from_bytes(uint8_t *data) {
   int32_t size = read_int32_le(&p);
 
   BsonObject obj;
-  bson_object_from_bytes_len(&obj, data, size);
+  size_t bytes = bson_object_from_bytes_len(&obj, data, size);
+  if (bytes <= 0) {
+    bson_object_initialize_default(&obj);
+  }
   return obj;
 }
 

--- a/test/bson_object_test.c
+++ b/test/bson_object_test.c
@@ -145,11 +145,16 @@ START_TEST(bson_object_from_bytes_corrupted_key)
   }
   memcpy(buf, test_data_corrupted, sizeof(test_data_corrupted));
 
+  // Test normal method
   BsonObject output;
   size_t ret = bson_object_from_bytes_len(&output, buf, sizeof(test_data_corrupted));
+
+  // Test deprecated method
+  BsonObject deprecated_output = bson_object_from_bytes(buf);
   free(buf);
 
   ck_assert_uint_eq(ret, 0);
+  ck_assert_uint_eq(bson_object_size(&deprecated_output), 5);
 }
 END_TEST
 
@@ -171,11 +176,16 @@ START_TEST(bson_object_from_bytes_corrupted_tag_length)
   }
   memcpy(buf, test_data_corrupted, sizeof(test_data_corrupted));
 
+  // Test normal method
   BsonObject output;
   size_t ret = bson_object_from_bytes_len(&output, buf, sizeof(test_data_corrupted));
+
+  // Test deprecated method
+  BsonObject deprecated_output = bson_object_from_bytes(buf);
   free(buf);
 
   ck_assert_uint_eq(ret, 0);
+  ck_assert_uint_eq(bson_object_size(&deprecated_output), 5);
 }
 END_TEST
 
@@ -197,11 +207,16 @@ START_TEST(bson_object_from_bytes_corrupted_string)
   }
   memcpy(buf, test_data_corrupted, sizeof(test_data_corrupted));
 
+  // Test normal method
   BsonObject output;
   size_t ret = bson_object_from_bytes_len(&output, buf, sizeof(test_data_corrupted));
+
+  // Test deprecated method
+  BsonObject deprecated_output = bson_object_from_bytes(buf);
   free(buf);
 
   ck_assert_uint_eq(ret, 0);
+  ck_assert_uint_eq(bson_object_size(&deprecated_output), 5);
 }
 END_TEST
 
@@ -223,11 +238,16 @@ START_TEST(bson_object_from_bytes_corrupted_integer)
   }
   memcpy(buf, test_data_corrupted, sizeof(test_data_corrupted));
 
+  // Test normal method
   BsonObject output;
   size_t ret = bson_object_from_bytes_len(&output, buf, sizeof(test_data_corrupted));
+
+  // Test deprecated method
+  BsonObject deprecated_output = bson_object_from_bytes(buf);
   free(buf);
 
   ck_assert_uint_eq(ret, 0);
+  ck_assert_uint_eq(bson_object_size(&deprecated_output), 5);
 }
 END_TEST
 
@@ -251,11 +271,16 @@ START_TEST(bson_object_from_bytes_corrupted_tag)
   }
   memcpy(buf, test_data_corrupted, sizeof(test_data_corrupted));
 
+  // Test normal method
   BsonObject output;
   size_t ret = bson_object_from_bytes_len(&output, buf, sizeof(test_data_corrupted));
+
+  // Test deprecated method
+  BsonObject deprecated_output = bson_object_from_bytes(buf);
   free(buf);
 
   ck_assert_uint_eq(ret, 0);
+  ck_assert_uint_eq(bson_object_size(&deprecated_output), 5);
 }
 END_TEST
 


### PR DESCRIPTION
When `bson_object_from_bytes` was deprecated, it's underlying behavior was changed so that it was possible that an uninitialized BsonObject would be returned. This fixes that behavior so an empty (but initialized) object is returned in this case instead.