### PR TITLE
Fix bintray repo name

### DIFF
--- a/BsonJavaPort/bson_java_port/bintray.gradle
+++ b/BsonJavaPort/bson_java_port/bintray.gradle
@@ -5,7 +5,7 @@ apply plugin: 'maven-publish'
 def siteUrl = 'https://github.com/smartdevicelink/bson_c_lib/'      // Homepage URL of the library
 def gitUrl = 'https://github.com/smartdevicelink/bson_c_lib.git'   // Git repository URL
 group = "com.smartdevicelink" // Maven Group ID for the artifact
-version = "X.X.X" // Set POM version here as well
+version = "1.2.2" // Set POM version here as well
 def libDescription = 'BSON library for SmartDeviceLink'
 
 install {

--- a/BsonJavaPort/bson_java_port/bintray.properties
+++ b/BsonJavaPort/bson_java_port/bintray.properties
@@ -4,5 +4,5 @@ bintray.repo=bson_android
 bintray.artifact=bson_java_port
 bintray.userorg=smartdevicelink
 bintray.publish=true
-bintray.version=x.x.x
-bintray.vcs=x.x.x
+bintray.version=1.2.2
+bintray.vcs=1.2.2

--- a/BsonJavaPort/bson_java_port/bintray.properties
+++ b/BsonJavaPort/bson_java_port/bintray.properties
@@ -1,8 +1,8 @@
 bintray.user=user
 bintray.key=key
-bintray.repo=sdl_android
+bintray.repo=bson_android
 bintray.artifact=bson_java_port
 bintray.userorg=smartdevicelink
-bintray.publish=false
+bintray.publish=true
 bintray.version=x.x.x
 bintray.vcs=x.x.x


### PR DESCRIPTION
This PR fixes an issue in `bintray.properties` file. It was using a wrong repo name