### PR TITLE
Update podspec iOS minimum version

### DIFF
--- a/BiSON.podspec
+++ b/BiSON.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.7"
   s.watchos.deployment_target = "2.0"
-  s.tvos.deployment_target = "10.0"
+  s.tvos.deployment_target = "9.0"
 
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/BiSON.podspec
+++ b/BiSON.podspec
@@ -48,10 +48,10 @@ Pod::Spec.new do |s|
   #
 
   #  When using multiple platforms
-  s.ios.deployment_target = "6.0"
+  s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.7"
   s.watchos.deployment_target = "2.0"
-  s.tvos.deployment_target = "9.0"
+  s.tvos.deployment_target = "10.0"
 
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #


### PR DESCRIPTION
Xcode 12 only supports iOS 9+, so warnings appear with the current minimum versions mentioned in the podspec. This PR bumps that to v9.0, the new minimum version.