### PR TITLE
Remove Xcode module map

### DIFF
--- a/BiSON.podspec
+++ b/BiSON.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "BiSON"
-  s.version      = "1.2.2"
+  s.version      = "1.2.3"
   s.summary      = "A portable BSON C library"
 
 

--- a/src/module.modulemap
+++ b/src/module.modulemap
@@ -1,8 +1,0 @@
-module bson {
-    header "emhashmap/emhashmap.h"
-    header "bson_object.h"
-    header "bson_array.h"
-    header "bson_util.h"
-
-    export *
-}


### PR DESCRIPTION
The Xcode module map is causing problems when building the bson submodule for the iOS library. Removing it alleviates the issue while also still allowing Cocoapods, Carthage, and SPM to function. Additionally, this bumps the podspec version to account for the new version tag that will need to be created.