### PR TITLE
Fix for potential memory leak in the bson_array.c file

### DIFF
--- a/src/bson_array.c
+++ b/src/bson_array.c
@@ -288,7 +288,7 @@ size_t bson_array_from_bytes_len(BsonArray *output, const uint8_t *data, size_t 
     }
   }
 
-  if (parseError) {
+  if (parseError || dataSize - remainBytes == 0) {
     bson_array_deinitialize(&array);
     return 0;
   }

--- a/src/bson_object.c
+++ b/src/bson_object.c
@@ -309,7 +309,7 @@ size_t bson_object_from_bytes_len(BsonObject *output, const uint8_t *data, size_
     }
   }
 
-  if (parseError) {
+  if (parseError || dataSize - remainBytes == 0) {
     bson_object_deinitialize(&obj);
     return 0;
   }


### PR DESCRIPTION
Fixes #33 

### Summary
Deinitialize variable to prevent a potential memory leak, when type = `DOCUMENT_END`